### PR TITLE
docs: add EPIC Sync badge to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [2025-09-09] - CI EPIC Progress Sync
 
+### Changed
+- README.md: Added EPIC Progress Sync status badge.
+
 ### Added
 - New GitHub Actions workflow `.github/workflows/epic-sync.yml` that runs `scripts/post_commit_sync.sh` in CI to post progress comments to EPIC issues.
   - Uses `GITHUB_TOKEN` with `issues: write` permission.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Documentation](https://github.com/erichowens/metal-shader-mcp/actions/workflows/documentation.yml/badge.svg)](https://github.com/erichowens/metal-shader-mcp/actions/workflows/documentation.yml)
 [![Visual Tests](https://github.com/erichowens/metal-shader-mcp/actions/workflows/visual-tests.yml/badge.svg)](https://github.com/erichowens/metal-shader-mcp/actions/workflows/visual-tests.yml)
 [![WARP Compliance](https://github.com/erichowens/metal-shader-mcp/actions/workflows/warp-compliance.yml/badge.svg)](https://github.com/erichowens/metal-shader-mcp/actions/workflows/warp-compliance.yml)
+[![EPIC Progress Sync](https://github.com/erichowens/metal-shader-mcp/actions/workflows/epic-sync.yml/badge.svg?branch=main)](https://github.com/erichowens/metal-shader-mcp/actions/workflows/epic-sync.yml)
 
 A complete system for AI-assisted Metal shader development where Claude can write, modify, and visually iterate on shaders in real-time.
 


### PR DESCRIPTION
Adds a live status badge for the EPIC Progress Sync workflow to README.md.\nAlso updates CHANGELOG.md per WARP after-action requirements.