### PR TITLE
feat(mcp): strict MCP client groundwork (Swift MCPBridge) + initial wiring

### DIFF
--- a/.github/workflows/swift-build.yml
+++ b/.github/workflows/swift-build.yml
@@ -7,17 +7,42 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   swift-metal-build:
     name: Swift/Metal Compilation
     runs-on: macos-latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    
+
+    - name: Determine change scope (paths-filter)
+      id: changes
+      uses: dorny/paths-filter@v3
+      with:
+        filters: |
+          swift:
+            - 'Package.swift'
+            - 'Sources/**'
+            - '*.swift'
+            - 'Resources/communication/*.metal'
+            - 'shaders/*.metal'
+          docs:
+            - '**/*.md'
+
+    - name: Short-circuit if no Swift or shader changes on PR
+      if: github.event_name == 'pull_request' && steps.changes.outputs.swift != 'true'
+      run: |
+        echo "No Swift/shader changes detected; skipping build."
+        echo "skipped=true" >> $GITHUB_OUTPUT
+        exit 0
+
     - name: Set up Xcode
-      uses: maxim-lobanov/setup-xcode@v1
+    
       with:
         xcode-version: latest-stable
     

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,15 +7,39 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Swift Tests and Quality Checks
     runs-on: macos-latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    
+
+    - name: Determine change scope (paths-filter)
+      id: changes
+      uses: dorny/paths-filter@v3
+      with:
+        filters: |
+          swift:
+            - 'Package.swift'
+            - 'Sources/**'
+            - '*.swift'
+            - 'Resources/communication/*.metal'
+            - 'shaders/*.metal'
+          tests:
+            - 'Tests/**'
+
+    - name: Short-circuit if no relevant changes on PR
+      if: github.event_name == 'pull_request' && steps.changes.outputs.swift != 'true' && steps.changes.outputs.tests != 'true'
+      run: |
+        echo "No Swift/tests changes detected; skipping."
+        exit 0
+
     - name: Set up Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:

--- a/.github/workflows/ui-smoke.yml
+++ b/.github/workflows/ui-smoke.yml
@@ -15,6 +15,9 @@ jobs:
   ui-smoke:
     runs-on: macos-latest
     timeout-minutes: 10
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -7,15 +7,39 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   visual-tests:
     name: Visual Testing and Screenshot Capture
     runs-on: macos-latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    
+
+    - name: Determine change scope (paths-filter)
+      id: changes
+      uses: dorny/paths-filter@v3
+      with:
+        filters: |
+          visual:
+            - 'Resources/screenshots/**'
+            - '*.swift'
+            - 'Sources/**'
+            - 'shaders/*.metal'
+            - 'Resources/communication/*.metal'
+
+    - name: Skip unless label or explicit push to main
+      if: |
+        github.event_name == 'pull_request' &&
+        !contains(join(github.event.pull_request.labels.*.name), 'visual-required')
+      run: |
+        echo "Skipping visual tests (no 'visual-required' label)."
+        exit 0
+
     - name: Set up Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -1,0 +1,41 @@
+# Agent Handoff: CI Modernization and MCP-First UI
+
+Owner: Automated Agent (this file is maintained so any agent can resume work)
+
+## Completed in PRs
+- feature/headless-mcp (PR #29)
+  - Headless Node/TS MCP helpers (set_shader, export_frame, extractDocstring)
+  - MCP Node/TypeScript Tests workflow
+  - PRIORITIES.md and weekly priorities-review workflow
+  - Swift fix: write current_shader_meta.json instead of library_index.json
+
+## In Progress (this branch: ci/modernization)
+- Add concurrency cancel-in-progress, path filters, and label-gating:
+  - swift-build.yml: added concurrency + paths-filter + PR short-circuit
+  - test.yml: added concurrency + paths-filter + PR short-circuit
+  - visual-tests.yml: added concurrency + label-gating (visual-required)
+  - ui-smoke.yml: added concurrency block
+
+## Next Steps
+1) Update branch protection on main to require (see PRIORITIES.md):
+   - MCP Node/TypeScript Tests
+   - Swift/Metal Build and Validation (smoke)
+   - UI Smoke (tab + status)
+2) Move heavy visual tests to non-blocking (only on label or main).
+3) Build strict MCP client in Swift (replace file-bridge). Plan:
+   - Create Sources/MetalShaderCore/MCPBridge.swift (protocol) and MCPLiveClient.swift (impl)
+   - Create tool schemas and map to UI actions; route all writes via MCP
+   - Remove file-bridge calls from ContentView/AppShellView
+4) Enhance UI for Artists & Learners:
+   - Library (searchable, annotated docstrings, examples)
+   - REPL (param sliders, FPS, compile errors)
+   - Archivist (snapshot compare, notes)
+   - Educator (guided tours, glossary)
+5) Visual baselines + pixel diff for select shaders.
+
+## Fallbacks
+- If macOS runners are slow, keep Node/TypeScript tests as the only required check until smoke jobs are stabilized.
+
+## Contacts / Links
+- Draft PR (headless MCP): https://github.com/erichowens/metal-shader-mcp/pull/29
+- PRIORITIES.md is the source of truth for required checks and rationale.

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -9,12 +9,19 @@ Owner: Automated Agent (this file is maintained so any agent can resume work)
   - PRIORITIES.md and weekly priorities-review workflow
   - Swift fix: write current_shader_meta.json instead of library_index.json
 
-## In Progress (this branch: ci/modernization)
-- Add concurrency cancel-in-progress, path filters, and label-gating:
-  - swift-build.yml: added concurrency + paths-filter + PR short-circuit
-  - test.yml: added concurrency + paths-filter + PR short-circuit
-  - visual-tests.yml: added concurrency + label-gating (visual-required)
-  - ui-smoke.yml: added concurrency block
+## In Progress (branches)
+- ci/modernization: CI speed-ups, concurrency, label-gating (PR #30)
+- feature/strict-mcp-client: strict MCP client in Swift (this branch)
+
+### Work started on strict MCP client
+- Added Sources/MetalShaderCore/MCPBridge.swift with MCPBridge protocol and FileBridgeMCP implementation (temporary bridge).
+- Refactored ShaderPlayground to use MCPBridge for exporting frames and snapshot-driven set_shader calls.
+
+### CI changes in flight
+- swift-build.yml: added concurrency + paths-filter + PR short-circuit
+- test.yml: added concurrency + paths-filter + PR short-circuit
+- visual-tests.yml: added concurrency + label-gating (visual-required)
+- ui-smoke.yml: added concurrency block
 
 ## Next Steps
 1) Update branch protection on main to require (see PRIORITIES.md):

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -23,6 +23,12 @@ Owner: Automated Agent (this file is maintained so any agent can resume work)
 - visual-tests.yml: added concurrency + label-gating (visual-required)
 - ui-smoke.yml: added concurrency block
 
+## Single-flight pull request policy
+To reduce cognitive load, we move forward one active PR at a time. All other related PRs are kept in draft until the current PR merges.
+
+Current active PR: #30 (CI modernization)
+Follow-ups (draft): #29 (headless MCP helpers), #32 (strict MCP client groundwork)
+
 ## Next Steps
 1) Update branch protection on main to require (see PRIORITIES.md):
    - MCP Node/TypeScript Tests

--- a/HistoryTabView.swift
+++ b/HistoryTabView.swift
@@ -291,33 +291,15 @@ struct SnapshotCard: View {
         } else {
             print("Warning: Could not read data from \(snapshot.jsonPath)")
         }
-        // Send set_shader command via bridge
-        let cmd: [String: Any] = [
-            "action": "set_shader",
-            "shader_code": code,
-            "description": "open_snapshot \(snapshot.id)",
-            "timestamp": Date().timeIntervalSince1970,
-            "no_snapshot": false
-        ]
-        if let data = try? JSONSerialization.data(withJSONObject: cmd, options: [.prettyPrinted]) {
-            try? FileManager.default.createDirectory(atPath: "Resources/communication", withIntermediateDirectories: true)
-            try? data.write(to: URL(fileURLWithPath: "Resources/communication/commands.json"))
-        }
+// Send set_shader via MCP bridge
+        let bridge = FileBridgeMCP()
+        bridge.setShader(code: code, name: nil, description: "open_snapshot \(snapshot.id)", path: nil, save: false, snapshot: true)
     }
 
     private func openInREPLSilent() {
         guard let code = try? String(contentsOfFile: snapshot.codePath, encoding: .utf8) else { return }
-        let cmd: [String: Any] = [
-            "action": "set_shader",
-            "shader_code": code,
-            "description": "open_snapshot_silent \(snapshot.id)",
-            "timestamp": Date().timeIntervalSince1970,
-            "no_snapshot": true
-        ]
-        if let data = try? JSONSerialization.data(withJSONObject: cmd, options: [.prettyPrinted]) {
-            try? FileManager.default.createDirectory(atPath: "Resources/communication", withIntermediateDirectories: true)
-            try? data.write(to: URL(fileURLWithPath: "Resources/communication/commands.json"))
-        }
+let bridge = FileBridgeMCP()
+        bridge.setShader(code: code, name: nil, description: "open_snapshot_silent \(snapshot.id)", path: nil, save: false, snapshot: false)
     }
 }
 

--- a/PRIORITIES.md
+++ b/PRIORITIES.md
@@ -1,0 +1,42 @@
+# Project Priorities (Single Source of Truth)
+
+This file captures our intent, rationale, and enforcement posture. Revisit weekly.
+
+## Must Do
+- MCP-first architecture. All shader lifecycle ops are driven via MCP tools. UI is a strict client (no hidden side-channels).
+- Deterministic, visual evidence for visual changes. Store under `Resources/screenshots/`.
+- Fast PR loop: required checks complete in ≤ 8 minutes.
+- Education-first: library with named shaders, descriptions, and approachable UI.
+
+## Should Do
+- Replace file-bridge with strict MCP client in Swift (no hidden side-channels).
+- Headless rendering/export APIs for batch runs and studies.
+- Parameter extraction and presets; librarian tooling with docstring metadata.
+- Baselines + visual diffing for key shaders.
+
+## Shouldn’t Do
+- UI-only features that can’t be triggered via MCP.
+- File-bridge hacks in new code (only tolerated in transitional glue).
+
+## Can’t Do
+- Secrets in repo or logs. Never leak keys.
+- Block merges without actionable feedback.
+
+## Won’t Do (for now)
+- Expensive, always-on heavy pipelines on every PR. Run on-demand/nightly.
+
+## Required checks (branch protection target)
+- MCP Node/TypeScript Tests
+- Swift/Metal Build and Validation (smoke)
+- UI Smoke (tab + status)
+
+## Rationale snapshot (Q3 2025)
+- Node/TypeScript tests: keep headless MCP tools deterministic and fast; validate parsing, IO, sequencing without macOS runner.
+- Swift/Metal smoke: ensure the app compiles and minimal render path works.
+- UI smoke: ensure shell tabs and status wiring remain healthy.
+
+## Review cadence
+- Weekly priorities-review workflow checks required checks vs branch protection.
+
+## Process policy
+- Single-flight PRs: only one active (non-draft) PR in flight for core work. Others remain draft and rebased after merge.

--- a/ShaderPlayground.swift
+++ b/ShaderPlayground.swift
@@ -41,6 +41,7 @@ struct ContentView: View {
     @StateObject private var renderer = MetalShaderRenderer()
     @StateObject private var session = SessionRecorder()
 @State private var shaderCode = defaultShader
+    private let mcp: MCPBridge = FileBridgeMCP()
     @State private var shaderMeta = ShaderMetadata.from(code: defaultShader, path: nil)
     
     let communicationDir = "Resources/communication"
@@ -107,8 +108,8 @@ VStack {
                     .padding()
                 
                 HStack {
-                    Button("Export Frame") {
-                        renderer.saveScreenshot()
+Button("Export Frame") {
+                        mcp.exportFrame(description: "manual_export", time: nil)
                     }
                     
                     Button("Export Sequence") {

--- a/Sources/MetalShaderCore/MCPBridge.swift
+++ b/Sources/MetalShaderCore/MCPBridge.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+public protocol MCPBridge {
+    func setShader(code: String, name: String?, description: String?, path: String?, save: Bool, snapshot: Bool)
+    func exportFrame(description: String, time: Float?)
+}
+
+public final class FileBridgeMCP: MCPBridge {
+    private let fm = FileManager.default
+    private let dir = "Resources/communication"
+
+    public init() {
+        try? fm.createDirectory(atPath: dir, withIntermediateDirectories: true)
+    }
+
+    public func setShader(code: String, name: String?, description: String?, path: String?, save: Bool, snapshot: Bool) {
+        var payload: [String: Any] = [
+            "action": (name != nil || description != nil || path != nil) ? "set_shader_with_meta" : "set_shader",
+            "shader_code": code,
+            "timestamp": Date().timeIntervalSince1970,
+            "no_snapshot": !snapshot
+        ]
+        if let name = name { payload["name"] = name }
+        if let description = description { payload["description"] = description }
+        if let p = path { payload["path"] = p }
+        payload["save"] = save
+        writeJSON(payload, to: dir + "/commands.json")
+    }
+
+    public func exportFrame(description: String, time: Float?) {
+        var payload: [String: Any] = [
+            "action": "export_frame",
+            "description": description,
+            "timestamp": Date().timeIntervalSince1970
+        ]
+        if let t = time { payload["time"] = t }
+        writeJSON(payload, to: dir + "/commands.json")
+    }
+
+    private func writeJSON(_ obj: [String: Any], to path: String) {
+        if let data = try? JSONSerialization.data(withJSONObject: obj, options: [.prettyPrinted]) {
+            try? data.write(to: URL(fileURLWithPath: path))
+        }
+    }
+}


### PR DESCRIPTION
This PR starts the migration to a strict MCP-first Swift client.\n\nChanges:\n- Adds  protocol and  (temporary bridge) in .\n- Wires MCP bridge usage for: \n  - Export Frame button in REPL\n  - Opening snapshots from History (both normal + silent)\n- Updates  to document status and next steps.\n\nNext steps (planned in this branch series):\n- Implement  that talks to the Node MCP (stdio/websocket).\n- Replace file-bridge calls with live MCP calls via .\n- Route UI writes (status/meta/library) through MCP tools; remove direct file writes.\n- Add Swift tests that verify UI actions call MCPBridge methods.\n\nThis keeps us aligned with MCP-first, testable, and reproducible workflows.